### PR TITLE
NewReq panic fix

### DIFF
--- a/e.go
+++ b/e.go
@@ -50,10 +50,11 @@ func (e *errstack) Error() string {
 	if message == "" {
 		message = "error"
 	}
-	if e.err == nil {
-		return e.message
+	errmsg := "nil"
+	if e.err != nil {
+		errmsg = e.err.Error()
 	}
-	return fmt.Sprintf("%s [%s]", e.message, e.err.Error())
+	return fmt.Sprint(message, " [", errmsg, "]")
 }
 
 func (e errstack) withMsg(msg string) errstack {

--- a/e.go
+++ b/e.go
@@ -50,6 +50,9 @@ func (e *errstack) Error() string {
 	if message == "" {
 		message = "error"
 	}
+	if e.err == nil {
+		return e.message
+	}
 	return fmt.Sprintf("%s [%s]", e.message, e.err.Error())
 }
 

--- a/e_test.go
+++ b/e_test.go
@@ -8,6 +8,23 @@ import (
 
 type ESuite struct{}
 
+func (s *ESuite) TestNewReq(c *C) {
+	// New request with no wrapping
+	err := NewReq("error-text")
+	c.Assert(err.Error(), Equals, "error-text")
+
+	// New request
+	nerr := NewReq("one")
+	b, errm := nerr.MarshalJSON()
+	c.Assert(errm, IsNil)
+	c.Assert(string(b), Equals, "{\"msg\":\"one\"}")
+
+	nerr = NewReq("two")
+	b, errm = nerr.MarshalJSON()
+	c.Assert(errm, IsNil)
+	c.Assert(string(b), Equals, "{\"msg\":\"two\"}")
+}
+
 func (s *ESuite) TestWrapAsReq(c *C) {
 	err := errors.New("new error")
 


### PR DESCRIPTION
Fixes panic that occurs if `NewReq().Error()` is called